### PR TITLE
Add dev branch CI, Dependabot target, and container image scanning/publish improvements

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: gomod
     directory: /
+    target-branch: dev
     schedule:
       interval: weekly
     labels:
@@ -19,6 +20,7 @@ updates:
 
   - package-ecosystem: docker
     directory: /
+    target-branch: dev
     schedule:
       interval: weekly
     labels:
@@ -32,6 +34,7 @@ updates:
 
   - package-ecosystem: github-actions
     directory: /
+    target-branch: dev
     schedule:
       interval: weekly
     labels:

--- a/.github/workflows/build and release.yml
+++ b/.github/workflows/build and release.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - main
+      - dev
   pull_request:
     branches:
       - main
+      - dev
 
 permissions: {}
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - main
+      - dev
   pull_request:
     branches:
       - main
+      - dev
   schedule:
     - cron: '29 20 * * 0'
 
@@ -23,6 +25,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -4,11 +4,13 @@ on:
   push:
     branches:
       - main
+      - dev
     tags:
       - 'v*'
   pull_request:
     branches:
       - main
+      - dev
 
 permissions: {}
 
@@ -21,8 +23,86 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  image:
-    name: Build image
+  pull-request:
+    name: Build and scan PR image
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: false
+          tags: logbook:scan
+          load: true
+          build-args: |
+            VERSION=${{ github.head_ref }}
+            COMMIT=${{ github.event.pull_request.head.sha }}
+            DATE=${{ github.event.pull_request.updated_at }}
+          cache-from: type=gha
+          provenance: false
+          sbom: false
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.36.0
+        with:
+          image-ref: logbook:scan
+          format: table
+
+  dev:
+    name: Build and scan dev image
+    if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: false
+          tags: logbook:scan
+          load: true
+          build-args: |
+            VERSION=${{ github.ref_name }}
+            COMMIT=${{ github.sha }}
+            DATE=${{ github.event.head_commit.timestamp }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: false
+          sbom: false
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.36.0
+        with:
+          image-ref: logbook:scan
+          format: sarif
+          output: trivy-results.sarif
+
+      - name: Upload Trivy scan results
+        if: hashFiles('trivy-results.sarif') != ''
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: trivy-results.sarif
+
+  publish:
+    name: Publish image
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -37,7 +117,6 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to registry
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
@@ -54,46 +133,44 @@ jobs:
             type=ref,event=tag
             type=sha,prefix=sha-
 
-      - name: Build image
+      - name: Build and push image
         id: build
         uses: docker/build-push-action@v7
         with:
           context: .
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ github.event_name == 'pull_request' && 'logbook:scan' || steps.meta.outputs.tags }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          load: ${{ github.event_name == 'pull_request' }}
           build-args: |
             VERSION=${{ github.ref_name }}
             COMMIT=${{ github.sha }}
-            DATE=${{ github.event_name == 'pull_request' && github.event.pull_request.updated_at || github.event.head_commit.timestamp }}
+            DATE=${{ github.event.head_commit.timestamp }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          provenance: ${{ github.event_name != 'pull_request' && 'mode=max' || 'false' }}
-          sbom: ${{ github.event_name != 'pull_request' }}
+          provenance: mode=max
+          sbom: true
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.36.0
         with:
-          image-ref: ${{ github.event_name == 'pull_request' && 'logbook:scan' || fromJSON(steps.meta.outputs.json).tags[0] }}
+          image-ref: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}@${{ steps.build.outputs.digest }}
           format: sarif
           output: trivy-results.sarif
 
       - name: Upload Trivy scan results
-        if: github.event_name != 'pull_request' && hashFiles('trivy-results.sarif') != ''
+        if: hashFiles('trivy-results.sarif') != ''
         uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: trivy-results.sarif
 
       - name: Install cosign
-        if: github.event_name != 'pull_request'
         uses: sigstore/cosign-installer@v4
 
       - name: Sign image
-        if: github.event_name != 'pull_request'
         env:
+          DIGEST: ${{ steps.build.outputs.digest }}
           TAGS: ${{ steps.meta.outputs.tags }}
         run: |
           while IFS= read -r tag; do
-            cosign sign --yes "${tag}@${{ steps.build.outputs.digest }}"
+            cosign sign --yes "${tag}@${DIGEST}"
           done <<< "${TAGS}"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Logbook
-[![Build](https://github.com/sundi0331/logbook/actions/workflows/build%20and%20release.yml/badge.svg?branch=main&event=push)](https://github.com/sundi0331/logbook/actions/workflows/build%20and%20release.yml)
-[![CodeQL](https://github.com/sundi0331/logbook/actions/workflows/codeql-analysis.yml/badge.svg?branch=main&event=push)](https://github.com/sundi0331/logbook/actions/workflows/codeql-analysis.yml)
-[![Container](https://github.com/sundi0331/logbook/actions/workflows/container.yml/badge.svg?branch=main&event=push)](https://github.com/sundi0331/logbook/actions/workflows/container.yml)
+[![Build](https://github.com/sundi0331/logbook/actions/workflows/build%20and%20release.yml/badge.svg?branch=dev&event=push)](https://github.com/sundi0331/logbook/actions/workflows/build%20and%20release.yml)
+[![CodeQL](https://github.com/sundi0331/logbook/actions/workflows/codeql-analysis.yml/badge.svg?branch=dev&event=push)](https://github.com/sundi0331/logbook/actions/workflows/codeql-analysis.yml)
+[![Container](https://github.com/sundi0331/logbook/actions/workflows/container.yml/badge.svg?branch=dev&event=push)](https://github.com/sundi0331/logbook/actions/workflows/container.yml)
 
 Logbook is a Kubernetes event logger which can be used either in-cluster(use kubernetes ServiceAccount for auth) or out-of-cluster(use kubeconfig file for auth). It logs kubernetes events to stdout or a file, which can be further processed by your logging pipeline, enabling you manage kubernetes events like container logs.
 


### PR DESCRIPTION
### Motivation
- Enable CI and dependency updates to target the `dev` branch and add container scanning and improved publish behavior for non-main workflows.
- Ensure CodeQL and Go toolchain are initialized correctly for analysis runs.
- Provide vulnerability scanning on PRs and dev builds and sign/publish images from main/tags.

### Description
- Added `target-branch: dev` to Dependabot entries for `gomod`, `docker`, and `github-actions` updates.
- Enabled `dev` branch triggers for the `build and release`, `codeql-analysis`, and `container` workflows and added a `Setup Go` step to CodeQL initialization using `actions/setup-go@v6`.
- Reworked `container.yml` into separate jobs: `pull-request` (builds image and runs Trivy with table output), `dev` (builds, scans to SARIF and uploads results), and `publish` (always pushes built images, enables provenance/SBOM, uploads Trivy SARIF, and signs images with `cosign` using the image `DIGEST`).
- Adjusted Docker build/push logic to use `docker/metadata-action` tags, always push in publish, and streamline build args; updated README badges to point at the `dev` branch.

### Testing
- No CI runs were executed as part of this change; the workflows now include a `Test` job that runs a `gofmt` check and CodeQL/Trivy steps for future runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c0eb8c8d483298df8a4feee5cc061)