### PR TITLE
Add kind smoke testing for Kubernetes deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 .git
+.cache
 .github
 .gitignore
 Dockerfile

--- a/.github/workflows/build and release.yml
+++ b/.github/workflows/build and release.yml
@@ -54,3 +54,25 @@ jobs:
 
       - name: Render Helm chart
         run: helm template logbook ./helmchart
+
+  smoke:
+    name: Smoke test in kind
+    runs-on: ubuntu-latest
+    needs: test
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Helm
+        uses: azure/setup-helm@v4
+
+      - name: Setup kind
+        uses: helm/kind-action@v1.14.0
+        with:
+          cluster_name: logbook-smoke
+          wait: 120s
+
+      - name: Run kind smoke test
+        run: bash hack/kind-smoke-test.sh

--- a/.github/workflows/build and release.yml
+++ b/.github/workflows/build and release.yml
@@ -59,6 +59,7 @@ jobs:
     name: Smoke test in kind
     runs-on: ubuntu-latest
     needs: test
+    timeout-minutes: 15
     permissions:
       contents: read
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,8 @@ logbook
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
+# Local tool caches
+.cache/
+
 # Dependency directories (remove the comment below to include it)
 # vendor/

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
 DATE ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 LDFLAGS := -s -w -X github.com/sundi0331/logbook/cmd.version=$(VERSION) -X github.com/sundi0331/logbook/cmd.commit=$(COMMIT) -X github.com/sundi0331/logbook/cmd.date=$(DATE)
 
-.PHONY: all fmt vet test tidy build build-linux-amd64 build-win-amd64 helm-lint helm-template docker-build verify clean
+.PHONY: all fmt vet test tidy build build-linux-amd64 build-win-amd64 helm-lint helm-template docker-build smoke-kind verify clean
 
 all: verify build
 
@@ -44,6 +44,9 @@ docker-build:
 		--build-arg COMMIT=$(COMMIT) \
 		--build-arg DATE=$(DATE) \
 		-t logbook:$(VERSION) .
+
+smoke-kind:
+	CREATE_CLUSTER=true bash hack/kind-smoke-test.sh
 
 verify: fmt vet test helm-lint helm-template
 

--- a/app/root_test.go
+++ b/app/root_test.go
@@ -1,0 +1,79 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+
+	eventsv1 "k8s.io/api/events/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+type staticEventWatcher struct {
+	list *eventsv1.EventList
+}
+
+func (s staticEventWatcher) List(context.Context, metav1.ListOptions) (*eventsv1.EventList, error) {
+	return s.list, nil
+}
+
+func (staticEventWatcher) Watch(context.Context, metav1.ListOptions) (watch.Interface, error) {
+	return watch.NewFake(), nil
+}
+
+func TestCurrentResourceVersionReturnsListVersion(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))
+	events := staticEventWatcher{
+		list: &eventsv1.EventList{
+			ListMeta: metav1.ListMeta{ResourceVersion: "123"},
+			Items: []eventsv1.Event{
+				{ObjectMeta: metav1.ObjectMeta{Name: "existing-event"}},
+			},
+		},
+	}
+
+	resourceVersion, err := currentResourceVersion(context.Background(), events, metav1.ListOptions{}, logger)
+	if err != nil {
+		t.Fatalf("currentResourceVersion() error = %v", err)
+	}
+	if resourceVersion != "123" {
+		t.Fatalf("currentResourceVersion() = %q, want 123", resourceVersion)
+	}
+}
+
+func TestConsumeEventsLogsObservedEvent(t *testing.T) {
+	var output bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&output, nil))
+	watcher := watch.NewFake()
+
+	go func() {
+		watcher.Add(&eventsv1.Event{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "smoke-event",
+				Namespace:       "default",
+				ResourceVersion: "456",
+			},
+			Reason: "SmokeTest",
+		})
+		watcher.Stop()
+	}()
+
+	resourceVersion, err := consumeEvents(context.Background(), watcher, logger)
+	if err != nil {
+		t.Fatalf("consumeEvents() error = %v", err)
+	}
+	if resourceVersion != "456" {
+		t.Fatalf("consumeEvents() resourceVersion = %q, want 456", resourceVersion)
+	}
+
+	logged := output.String()
+	if !strings.Contains(logged, "kubernetes event observed") {
+		t.Fatalf("consumeEvents() log = %q, want observed event message", logged)
+	}
+	if !strings.Contains(logged, "SmokeTest") {
+		t.Fatalf("consumeEvents() log = %q, want event reason", logged)
+	}
+}

--- a/hack/kind-smoke-test.sh
+++ b/hack/kind-smoke-test.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CLUSTER_NAME="${KIND_CLUSTER_NAME:-logbook-smoke}"
+RELEASE_NAME="${RELEASE_NAME:-logbook}"
+NAMESPACE="${NAMESPACE:-logbook-smoke}"
+IMAGE_REPOSITORY="${IMAGE_REPOSITORY:-logbook}"
+IMAGE_TAG="${IMAGE_TAG:-smoke}"
+TIMEOUT="${TIMEOUT:-120s}"
+CREATE_CLUSTER="${CREATE_CLUSTER:-false}"
+
+cleanup() {
+  if [[ "${CREATE_CLUSTER}" == "true" ]]; then
+    kind delete cluster --name "${CLUSTER_NAME}"
+  else
+    kubectl delete namespace "${NAMESPACE}" --ignore-not-found --wait=false >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "required command not found: $1" >&2
+    exit 1
+  fi
+}
+
+require_command docker
+require_command helm
+require_command kind
+require_command kubectl
+
+if [[ "${CREATE_CLUSTER}" == "true" ]]; then
+  kind create cluster --name "${CLUSTER_NAME}" --wait "${TIMEOUT}"
+fi
+
+docker build \
+  --build-arg VERSION=smoke \
+  --build-arg COMMIT="$(git rev-parse --short HEAD 2>/dev/null || echo unknown)" \
+  --build-arg DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  -t "${IMAGE_REPOSITORY}:${IMAGE_TAG}" .
+
+kind load docker-image "${IMAGE_REPOSITORY}:${IMAGE_TAG}" --name "${CLUSTER_NAME}"
+
+kubectl create namespace "${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
+
+helm upgrade --install "${RELEASE_NAME}" ./helmchart \
+  --namespace "${NAMESPACE}" \
+  --set "image.repository=${IMAGE_REPOSITORY}" \
+  --set "image.tag=${IMAGE_TAG}" \
+  --set "image.pullPolicy=Never" \
+  --set "logbook.namespace=${NAMESPACE}" \
+  --wait \
+  --timeout "${TIMEOUT}"
+
+kubectl rollout status "deployment/${RELEASE_NAME}" --namespace "${NAMESPACE}" --timeout "${TIMEOUT}"
+kubectl create configmap logbook-smoke-subject --namespace "${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
+
+for attempt in $(seq 1 30); do
+  event_name="logbook-smoke-${attempt}"
+  event_time="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+  cat <<EOF | kubectl apply -f -
+apiVersion: events.k8s.io/v1
+kind: Event
+metadata:
+  name: ${event_name}
+  namespace: ${NAMESPACE}
+eventTime: "${event_time}"
+reportingController: logbook-smoke
+reportingInstance: smoke-test
+action: Testing
+reason: LogbookSmokeTest
+type: Normal
+note: logbook smoke test event ${attempt}
+regarding:
+  apiVersion: v1
+  kind: ConfigMap
+  name: logbook-smoke-subject
+  namespace: ${NAMESPACE}
+EOF
+
+  sleep 2
+  if kubectl logs "deployment/${RELEASE_NAME}" --namespace "${NAMESPACE}" --since=5m | grep -q "LogbookSmokeTest"; then
+    kubectl logs "deployment/${RELEASE_NAME}" --namespace "${NAMESPACE}" --tail=20
+    exit 0
+  fi
+done
+
+kubectl describe "deployment/${RELEASE_NAME}" --namespace "${NAMESPACE}" >&2 || true
+kubectl get pods --namespace "${NAMESPACE}" -o wide >&2 || true
+kubectl logs "deployment/${RELEASE_NAME}" --namespace "${NAMESPACE}" --tail=100 >&2 || true
+echo "logbook did not observe the smoke test event" >&2
+exit 1

--- a/hack/kind-smoke-test.sh
+++ b/hack/kind-smoke-test.sh
@@ -58,7 +58,7 @@ kubectl create configmap logbook-smoke-subject --namespace "${NAMESPACE}" --dry-
 
 for attempt in $(seq 1 30); do
   event_name="logbook-smoke-${attempt}"
-  event_time="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  event_time="$(date -u +%Y-%m-%dT%H:%M:%S.000000Z)"
 
   cat <<EOF | kubectl apply -f -
 apiVersion: events.k8s.io/v1


### PR DESCRIPTION
### Motivation
- The current CI catches Go, Helm rendering, and container build issues, but it does not prove the application can run against a real Kubernetes API server.
- Logbook depends on in-cluster auth, RBAC, Helm values, image startup, and the `events.k8s.io/v1` watch loop all working together, so a lightweight smoke test belongs in CI as a separate job.

### Description
- Add `app/root_test.go` unit coverage for resource-version initialization and event consumption/logging.
- Add `hack/kind-smoke-test.sh`, which builds the image, loads it into a kind cluster, installs the Helm chart with namespaced RBAC, creates real `events.k8s.io/v1` Events, and fails unless Logbook observes the event in pod logs.
- Add a separate `Smoke test in kind` job to the Build workflow after the fast test/lint job, with a 15-minute timeout.
- Add `make smoke-kind` for local execution with a temporary kind cluster.
- Ignore `.cache/` locally and in Docker build context.

### Testing
- Locally ran `bash -n hack/kind-smoke-test.sh`.
- Locally ran `go test ./...`.
- Locally ran `go vet ./...`.
- Locally ran `go mod tidy`.
- GitHub Actions Build run #217 passed, including the new `Smoke test in kind` job.
- GitHub Actions Container run #10 passed.