### PR TITLE
Fix cosign installer action refs

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -161,7 +161,7 @@ jobs:
           sarif_file: trivy-results.sarif
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v4
+        uses: sigstore/cosign-installer@v4.1.2
 
       - name: Sign image
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,7 +181,7 @@ jobs:
           sarif_file: trivy-results.sarif
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v4
+        uses: sigstore/cosign-installer@v4.1.2
 
       - name: Sign release image
         env:


### PR DESCRIPTION
### Motivation
- The post-merge `Container` workflow on `main` failed before running steps because `sigstore/cosign-installer@v4` is not a valid action tag.
- The same invalid ref exists in the tag/manual Release workflow and would fail release publishing as well.

### Description
- Pin `sigstore/cosign-installer` to the current valid `v4.1.2` tag in `.github/workflows/container.yml`.
- Pin the same valid tag in `.github/workflows/release.yml`.

### Testing
- Confirmed the failing main run stopped with: `Unable to resolve action sigstore/cosign-installer@v4, unable to find version v4`.
- Confirmed valid upstream tags include `v4.1.2`.
- Build #223 passed: formatting, `go test ./...`, `go vet ./...`, tidy check, Helm lint/template, and kind smoke test.
- Container #16 passed: PR image build and Trivy scan.