### PR TITLE
Attach container SBOM attestations

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -145,7 +145,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           provenance: mode=max
-          sbom: true
+          sbom: false
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@v0.36.0
@@ -162,6 +162,35 @@ jobs:
 
       - name: Install cosign
         uses: sigstore/cosign-installer@v4.1.2
+
+      - name: Install Syft
+        id: syft
+        uses: anchore/sbom-action/download-syft@v0
+
+      - name: Generate image SBOM
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+          "${{ steps.syft.outputs.cmd }}" "${REGISTRY}/${IMAGE_NAME}@${DIGEST}" -o spdx-json=sbom.spdx.json
+
+      - name: Attest image SBOM
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+          cosign attest --yes --predicate sbom.spdx.json --type spdxjson "${REGISTRY}/${IMAGE_NAME}@${DIGEST}"
+
+      - name: Verify image SBOM attestation
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+          cosign verify-attestation \
+            --type spdxjson \
+            --certificate-identity-regexp "https://github.com/${GITHUB_REPOSITORY}/.github/workflows/.*" \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            "${REGISTRY}/${IMAGE_NAME}@${DIGEST}"
 
       - name: Sign image
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,7 +165,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           provenance: mode=max
-          sbom: true
+          sbom: false
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@v0.36.0
@@ -182,6 +182,35 @@ jobs:
 
       - name: Install cosign
         uses: sigstore/cosign-installer@v4.1.2
+
+      - name: Install Syft
+        id: syft
+        uses: anchore/sbom-action/download-syft@v0
+
+      - name: Generate release image SBOM
+        env:
+          DIGEST: ${{ steps.build-image.outputs.digest }}
+        run: |
+          set -euo pipefail
+          "${{ steps.syft.outputs.cmd }}" "${REGISTRY}/${IMAGE_NAME}@${DIGEST}" -o spdx-json=sbom.spdx.json
+
+      - name: Attest release image SBOM
+        env:
+          DIGEST: ${{ steps.build-image.outputs.digest }}
+        run: |
+          set -euo pipefail
+          cosign attest --yes --predicate sbom.spdx.json --type spdxjson "${REGISTRY}/${IMAGE_NAME}@${DIGEST}"
+
+      - name: Verify release image SBOM attestation
+        env:
+          DIGEST: ${{ steps.build-image.outputs.digest }}
+        run: |
+          set -euo pipefail
+          cosign verify-attestation \
+            --type spdxjson \
+            --certificate-identity-regexp "https://github.com/${GITHUB_REPOSITORY}/.github/workflows/.*" \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            "${REGISTRY}/${IMAGE_NAME}@${DIGEST}"
 
       - name: Sign release image
         env:
@@ -213,7 +242,7 @@ jobs:
 
               ${IMAGE}@${IMAGE_DIGEST}
 
-          Verify downloaded archives with SHA256SUMS.
+          Verify downloaded archives with SHA256SUMS. The release image also includes a cosign-verifiable SPDX SBOM attestation.
           EOF
 
       - name: Release

--- a/README.md
+++ b/README.md
@@ -61,4 +61,4 @@ git tag -a v1.2.3 -m "v1.2.3"
 git push origin v1.2.3
 ```
 
-The Release workflow validates the `vMAJOR.MINOR.PATCH` tag, builds packaged binaries for Linux, macOS, and Windows, publishes a GitHub Release with `SHA256SUMS`, publishes GHCR release images, scans the image with Trivy, and signs the published image tags with cosign. Manual workflow dispatch is for rerunning an existing tag release; it does not create new tags.
+The Release workflow validates the `vMAJOR.MINOR.PATCH` tag, builds packaged binaries for Linux, macOS, and Windows, publishes a GitHub Release with `SHA256SUMS`, publishes GHCR release images, scans the image with Trivy, signs the published image tags with cosign, and attaches a cosign-verifiable SPDX SBOM attestation. Manual workflow dispatch is for rerunning an existing tag release; it does not create new tags.


### PR DESCRIPTION
## Summary

Add explicit cosign-verifiable SPDX SBOM attestations for pushed container images.

Changes:

- Generate SPDX JSON SBOMs with Syft for pushed image digests
- Attach SBOMs with `cosign attest --type spdxjson`
- Verify the SBOM attestation immediately after publishing it
- Disable BuildKit's separate SBOM attestation on pushed images to keep the cosign attestation canonical
- Update release notes text and README release workflow description

## Validation

The updated `dev` branch passed:

- CI
- Container Image
- CodeQL

Note: the new attestation path runs for `main` snapshot image publication and release image publication. PR/dev workflows do not push images to GHCR, so the full publish/attest path is exercised after merge to `main` or during a release run.
