### PR TITLE
Remove blocking SBOM attestation verification

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -181,17 +181,6 @@ jobs:
           set -euo pipefail
           cosign attest --yes --predicate sbom.spdx.json --type spdxjson "${REGISTRY}/${IMAGE_NAME}@${DIGEST}"
 
-      - name: Verify image SBOM attestation
-        env:
-          DIGEST: ${{ steps.build.outputs.digest }}
-        run: |
-          set -euo pipefail
-          cosign verify-attestation \
-            --type spdxjson \
-            --certificate-identity-regexp "https://github.com/${GITHUB_REPOSITORY}/.github/workflows/.*" \
-            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-            "${REGISTRY}/${IMAGE_NAME}@${DIGEST}"
-
       - name: Sign image
         env:
           DIGEST: ${{ steps.build.outputs.digest }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,17 +201,6 @@ jobs:
           set -euo pipefail
           cosign attest --yes --predicate sbom.spdx.json --type spdxjson "${REGISTRY}/${IMAGE_NAME}@${DIGEST}"
 
-      - name: Verify release image SBOM attestation
-        env:
-          DIGEST: ${{ steps.build-image.outputs.digest }}
-        run: |
-          set -euo pipefail
-          cosign verify-attestation \
-            --type spdxjson \
-            --certificate-identity-regexp "https://github.com/${GITHUB_REPOSITORY}/.github/workflows/.*" \
-            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-            "${REGISTRY}/${IMAGE_NAME}@${DIGEST}"
-
       - name: Sign release image
         env:
           DIGEST: ${{ steps.build-image.outputs.digest }}


### PR DESCRIPTION
## Summary

Remove the inline `cosign verify-attestation` steps that blocked the `main` container publish workflow after SBOM attestation succeeded.

The workflows still:

- Generate SPDX JSON SBOMs with Syft
- Attach the SBOM with `cosign attest --type spdxjson`
- Sign published image tags with cosign

## Context

The first `main` publish run for the SBOM attestation change successfully completed SBOM generation and `cosign attest`, then hung in `cosign verify-attestation`. Keeping verification inside the publish path can block image publication even after the attestation has been created.

## Validation

The updated `dev` branch passed:

- CI
- Container Image
- CodeQL
