### PR TITLE
Add event checkpointing and leader election

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,19 @@
 
 Logbook is a Go-based Kubernetes event logger. It runs either in-cluster with a Kubernetes ServiceAccount or out-of-cluster with a kubeconfig.
 
+It watches Kubernetes Events through the stable `events.k8s.io/v1` API and writes observed watch events to the configured log sink. In Helm deployments, checkpointing and leader election are enabled by default so restarts avoid replaying already processed Events and multiple replicas do not duplicate the stream.
+
+## Development workflow
+
+- Follow TDD for behavior changes:
+  - Write or update a failing test that describes the desired behavior before changing implementation code.
+  - Make the smallest implementation change that makes the test pass.
+  - Refactor only after tests are green.
+- Keep tests focused on the affected behavior. Broaden coverage when changing shared runtime paths such as event watching, checkpointing, leader election, config loading, logging, or Helm chart output.
+- For bug fixes, add a regression test that would fail without the fix.
+- For config or Helm changes, update the docs, sample config, `values.yaml`, `values.schema.json`, templates, and tests/validation together.
+- Do not silently change defaults. If a default changes, update README and Helm values comments in the same change.
+
 ## Go conventions
 
 - Target the Go version declared in `go.mod`.
@@ -14,6 +27,10 @@ Logbook is a Go-based Kubernetes event logger. It runs either in-cluster with a 
 - Pass `context.Context` through long-running operations.
 - Avoid package-level mutable state unless it is required by a CLI framework.
 - Run `gofmt` on all Go files.
+- Keep long-running loops cancellable through `context.Context`.
+- Avoid unnecessary Kubernetes API writes. Coalesce or debounce writes where practical.
+- When adding a config field, expose it consistently through struct config, Cobra flags, Viper/env binding, sample YAML, README, and Helm when applicable.
+- When adding dependencies, run `go mod tidy` and inspect `go.mod`/`go.sum` changes.
 
 ## Kubernetes conventions
 
@@ -21,6 +38,13 @@ Logbook is a Go-based Kubernetes event logger. It runs either in-cluster with a 
 - Keep RBAC least-privilege.
 - Follow restricted Pod Security Standards where practical.
 - Quote Helm-rendered environment variable values.
+- Use `coordination.k8s.io/v1` Leases for leader election.
+- Helm deployments should keep leader election enabled by default.
+- Store ConfigMap checkpoints through the Kubernetes API, not a mounted ConfigMap volume.
+- Keep checkpoint writes buffered by default to avoid excessive API server and etcd write load.
+- When changing Kubernetes API calls, verify the Helm RBAC verbs match the actual client-go methods used.
+- Keep Helm `values.schema.json` in sync with supported values.
+- Kubernetes Events can contain sensitive operational information. Preserve README/security notes when changing event output behavior.
 
 ## Docker conventions
 
@@ -46,3 +70,8 @@ Run the relevant subset before submitting changes:
 - `helm lint ./helmchart`
 - `helm template logbook ./helmchart`
 - `docker build .`
+
+If the default Go build or module cache is not writable in the development environment, use temporary caches, for example:
+
+- `GOCACHE=/tmp/logbook-go-cache GOMODCACHE=/tmp/logbook-go-mod-cache go test ./...`
+- `GOCACHE=/tmp/logbook-go-cache GOMODCACHE=/tmp/logbook-go-mod-cache go vet ./...`

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
 DATE ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 LDFLAGS := -s -w -X github.com/sundi0331/logbook/cmd.version=$(VERSION) -X github.com/sundi0331/logbook/cmd.commit=$(COMMIT) -X github.com/sundi0331/logbook/cmd.date=$(DATE)
 
-.PHONY: all fmt vet test tidy build build-linux-amd64 build-win-amd64 helm-lint helm-template docker-build smoke-kind verify clean
+.PHONY: all fmt vet test tidy build build-linux-amd64 build-win-amd64 helm-lint helm-template helm-template-long-names docker-build smoke-kind verify clean
 
 all: verify build
 
@@ -38,6 +38,10 @@ helm-template:
 	command -v helm >/dev/null
 	helm template logbook ./helmchart
 
+helm-template-long-names:
+	command -v helm >/dev/null
+	helm template aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ./helmchart | awk '/^kind: /{kind=$$2} /^metadata:/{inmeta=1} inmeta && /^  name: /{name=$$2; if (length(name) > 63) {printf "%s metadata.name %s has length %d\n", kind, name, length(name); invalid=1}} /^(spec|rules|roleRef|subjects|data):/{inmeta=0} END{exit invalid}'
+
 docker-build:
 	docker build \
 		--build-arg VERSION=$(VERSION) \
@@ -48,7 +52,7 @@ docker-build:
 smoke-kind:
 	CREATE_CLUSTER=true bash hack/kind-smoke-test.sh
 
-verify: fmt vet test helm-lint helm-template
+verify: fmt vet test helm-lint helm-template helm-template-long-names
 
 clean:
 	rm -f $(BINARY) $(BINARY)_linux_amd64 $(BINARY)_windows_amd64.exe

--- a/README.md
+++ b/README.md
@@ -41,6 +41,20 @@ helm install RELEASE_NAME ./helmchart --namespace=INSTALL_NAMESPACE
 |  log-out  |  LOGBOOK_LOG_OUT  |  Log output (default is stdout)<br>Valid values: stdout, stderr, file  |
 |  log-level  |  LOGBOOK_LOG_LEVEL  |  Log level (default is info)<br>Valid values: debug, info, warn, error  |
 |  log-filename  |  LOGBOOK_LOG_FILENAME  |  Full path of log file with filename (valid only when log-out is set to file. Default is k8s-events.log in the same directory as logbook)  |
+|  checkpoint-enabled  |  LOGBOOK_CHECKPOINT_ENABLED  |  Enable Kubernetes Event resourceVersion checkpointing (default is true)  |
+|  checkpoint-backend  |  LOGBOOK_CHECKPOINT_BACKEND  |  Checkpoint backend (default is configmap)<br>Valid values: configmap, file  |
+|  checkpoint-namespace  |  LOGBOOK_CHECKPOINT_NAMESPACE  |  Namespace for the checkpoint ConfigMap (default is POD_NAMESPACE or default; Helm sets this to the release namespace)  |
+|  checkpoint-name  |  LOGBOOK_CHECKPOINT_NAME  |  Name of the checkpoint ConfigMap (default is logbook-checkpoint)  |
+|  checkpoint-path  |  LOGBOOK_CHECKPOINT_PATH  |  Path for the file checkpoint backend (default is logbook-checkpoint)  |
+|  checkpoint-flush-interval  |  LOGBOOK_CHECKPOINT_FLUSH_INTERVAL  |  Coalesce checkpoint writes and flush the latest resourceVersion at this interval (default is 5s; set to 0s to flush every event)  |
+|  checkpoint-on-expired-resource-version  |  LOGBOOK_CHECKPOINT_ON_EXPIRED_RESOURCE_VERSION  |  Behavior when Kubernetes has compacted the saved resourceVersion (default is skip-existing)<br>Valid values: skip-existing, fail  |
+|  leader-election-enabled  |  LOGBOOK_LEADER_ELECTION_ENABLED  |  Enable Kubernetes Lease leader election (default is false for the binary; Helm enables it by default)  |
+|  leader-election-namespace  |  LOGBOOK_LEADER_ELECTION_NAMESPACE  |  Namespace for the leader election Lease (default is POD_NAMESPACE or default; Helm sets this to the release namespace)  |
+|  leader-election-name  |  LOGBOOK_LEADER_ELECTION_NAME  |  Name of the leader election Lease (default is logbook-leader)  |
+|  leader-election-identity  |  LOGBOOK_LEADER_ELECTION_IDENTITY  |  Identity for this leader election candidate (default is POD_NAME or hostname; Helm uses the pod name)  |
+|  leader-election-lease-duration  |  LOGBOOK_LEADER_ELECTION_LEASE_DURATION  |  Leader election lease duration (default is 15s)  |
+|  leader-election-renew-deadline  |  LOGBOOK_LEADER_ELECTION_RENEW_DEADLINE  |  Leader election renew deadline (default is 10s)  |
+|  leader-election-retry-period  |  LOGBOOK_LEADER_ELECTION_RETRY_PERIOD  |  Leader election retry period (default is 2s)  |
 
 
 ## Development
@@ -51,6 +65,16 @@ make build
 ```
 
 Logbook watches Kubernetes Events through the stable `events.k8s.io/v1` API.
+
+By default, Logbook persists the last processed Kubernetes Event `resourceVersion` and resumes from it after a restart. Helm deployments use a ConfigMap checkpoint in the release namespace. Checkpoint writes are buffered and flushed every 5 seconds to reduce Kubernetes API and etcd write load. Set `--checkpoint-enabled=false` or `LOGBOOK_CHECKPOINT_ENABLED=false` to opt out.
+
+The `file` checkpoint backend requires a writable checkpoint path. Helm mounts a writable `emptyDir` at `/var/lib/logbook` when `logbook.checkpoint.backend=file`; this survives container restarts in the same Pod, but not Pod replacement or rescheduling. Helm requires `replicaCount=1` for the file backend because each Pod has its own `emptyDir`; use the default `configmap` backend for multiple replicas.
+
+Helm deployments enable Kubernetes Lease leader election by default, so only the elected Logbook replica streams events and writes checkpoints. This prevents duplicate logs when `replicaCount` is greater than 1.
+
+When enabling ConfigMap checkpointing outside the Helm chart, grant `get`, `create`, and `patch` on the checkpoint ConfigMap. When enabling leader election outside the Helm chart, grant `get`, `create`, `update`, and `patch` on the leader election Lease.
+
+Kubernetes Events may contain operationally sensitive object names, namespaces, references, and notes. Treat Logbook output as cluster operational data and route it only to logging systems with appropriate access controls.
 
 ## Release Procedure
 

--- a/app/checkpoint.go
+++ b/app/checkpoint.go
@@ -1,0 +1,253 @@
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	coreclientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
+
+	"github.com/sundi0331/logbook/config"
+)
+
+const checkpointResourceVersionKey = "resourceVersion"
+
+type checkpointStore interface {
+	Load(ctx context.Context) (string, error)
+	Save(ctx context.Context, resourceVersion string) error
+	Flush(ctx context.Context) error
+}
+
+type fileCheckpointStore struct {
+	path string
+}
+
+func newFileCheckpointStore(path string) *fileCheckpointStore {
+	return &fileCheckpointStore{path: path}
+}
+
+func (s *fileCheckpointStore) Load(context.Context) (string, error) {
+	data, err := os.ReadFile(s.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", fmt.Errorf("read checkpoint file %q: %w", s.path, err)
+	}
+	return strings.TrimSpace(string(data)), nil
+}
+
+func (s *fileCheckpointStore) Save(_ context.Context, resourceVersion string) error {
+	if err := os.MkdirAll(filepath.Dir(s.path), 0o750); err != nil {
+		return fmt.Errorf("create checkpoint directory %q: %w", filepath.Dir(s.path), err)
+	}
+
+	tmp := fmt.Sprintf("%s.%d.tmp", s.path, time.Now().UnixNano())
+	if err := os.WriteFile(tmp, []byte(resourceVersion), 0o640); err != nil {
+		return fmt.Errorf("write checkpoint file %q: %w", tmp, err)
+	}
+	if err := os.Rename(tmp, s.path); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("replace checkpoint file %q: %w", s.path, err)
+	}
+	return nil
+}
+
+func (s *fileCheckpointStore) Flush(context.Context) error {
+	return nil
+}
+
+type configMapCheckpointStore struct {
+	configMaps coreclientv1.ConfigMapInterface
+	name       string
+	mu         sync.Mutex
+	exists     bool
+}
+
+func newConfigMapCheckpointStore(configMaps coreclientv1.ConfigMapInterface, name string) *configMapCheckpointStore {
+	return &configMapCheckpointStore{configMaps: configMaps, name: name}
+}
+
+func (s *configMapCheckpointStore) Load(ctx context.Context) (string, error) {
+	checkpoint, err := s.configMaps.Get(ctx, s.name, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			s.setExists(false)
+			return "", nil
+		}
+		return "", fmt.Errorf("get checkpoint ConfigMap %q: %w", s.name, err)
+	}
+	s.setExists(true)
+	return checkpoint.Data[checkpointResourceVersionKey], nil
+}
+
+func (s *configMapCheckpointStore) Save(ctx context.Context, resourceVersion string) error {
+	exists := s.checkpointExists()
+	for {
+		if !exists {
+			checkpoint := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: s.name},
+				Data: map[string]string{
+					checkpointResourceVersionKey: resourceVersion,
+				},
+			}
+			if _, err := s.configMaps.Create(ctx, checkpoint, metav1.CreateOptions{}); err != nil {
+				if apierrors.IsAlreadyExists(err) {
+					s.setExists(true)
+					exists = true
+					continue
+				}
+				return fmt.Errorf("create checkpoint ConfigMap %q: %w", s.name, err)
+			}
+			s.setExists(true)
+			return nil
+		}
+
+		patch, err := json.Marshal(map[string]map[string]string{
+			"data": {
+				checkpointResourceVersionKey: resourceVersion,
+			},
+		})
+		if err != nil {
+			return fmt.Errorf("marshal checkpoint ConfigMap patch: %w", err)
+		}
+		_, err = s.configMaps.Patch(ctx, s.name, types.MergePatchType, patch, metav1.PatchOptions{})
+		if err == nil {
+			s.setExists(true)
+			return nil
+		}
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("patch checkpoint ConfigMap %q: %w", s.name, err)
+		}
+		s.setExists(false)
+		exists = false
+	}
+}
+
+func (s *configMapCheckpointStore) Flush(context.Context) error {
+	return nil
+}
+
+func (s *configMapCheckpointStore) checkpointExists() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.exists
+}
+
+func (s *configMapCheckpointStore) setExists(exists bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.exists = exists
+}
+
+type bufferedCheckpointStore struct {
+	store checkpointStore
+
+	mu      sync.Mutex
+	latest  string
+	flushed string
+	dirty   bool
+}
+
+func newBufferedCheckpointStore(store checkpointStore) *bufferedCheckpointStore {
+	return &bufferedCheckpointStore{store: store}
+}
+
+func (s *bufferedCheckpointStore) Load(ctx context.Context) (string, error) {
+	resourceVersion, err := s.store.Load(ctx)
+	if err != nil {
+		return "", err
+	}
+	s.mu.Lock()
+	s.latest = resourceVersion
+	s.flushed = resourceVersion
+	s.dirty = false
+	s.mu.Unlock()
+	return resourceVersion, nil
+}
+
+func (s *bufferedCheckpointStore) Save(_ context.Context, resourceVersion string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.latest = resourceVersion
+	s.dirty = resourceVersion != s.flushed
+	return nil
+}
+
+func (s *bufferedCheckpointStore) Flush(ctx context.Context) error {
+	s.mu.Lock()
+	if !s.dirty || s.latest == "" {
+		s.mu.Unlock()
+		return nil
+	}
+	resourceVersion := s.latest
+	s.mu.Unlock()
+
+	if err := s.store.Save(ctx, resourceVersion); err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	if s.latest == resourceVersion {
+		s.flushed = resourceVersion
+		s.dirty = false
+	}
+	s.mu.Unlock()
+	return nil
+}
+
+func newCheckpointStore(cfg config.CheckpointConfig, coreClient *coreclientv1.CoreV1Client) (checkpointStore, error) {
+	if !cfg.Enabled {
+		return nil, nil
+	}
+
+	var store checkpointStore
+	switch cfg.Backend {
+	case "configmap":
+		if coreClient == nil {
+			return nil, fmt.Errorf("create configmap checkpoint store: Kubernetes core client is required")
+		}
+		namespace := cfg.Namespace
+		if namespace == "" {
+			namespace = os.Getenv("POD_NAMESPACE")
+		}
+		if namespace == "" {
+			namespace = "default"
+		}
+		store = newConfigMapCheckpointStore(coreClient.ConfigMaps(namespace), cfg.Name)
+	case "file":
+		store = newFileCheckpointStore(cfg.Path)
+	default:
+		return nil, fmt.Errorf("unsupported checkpoint backend %q: expected configmap or file", cfg.Backend)
+	}
+
+	flushInterval, err := checkpointFlushInterval(cfg)
+	if err != nil {
+		return nil, err
+	}
+	if flushInterval <= 0 {
+		return store, nil
+	}
+	return newBufferedCheckpointStore(store), nil
+}
+
+func checkpointFlushInterval(cfg config.CheckpointConfig) (time.Duration, error) {
+	if cfg.FlushInterval == "" {
+		return 0, nil
+	}
+	flushInterval, err := time.ParseDuration(cfg.FlushInterval)
+	if err != nil {
+		return 0, fmt.Errorf("parse checkpoint flush interval %q: %w", cfg.FlushInterval, err)
+	}
+	return flushInterval, nil
+}

--- a/app/leader.go
+++ b/app/leader.go
@@ -1,0 +1,159 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"time"
+
+	"k8s.io/client-go/kubernetes/typed/coordination/v1"
+	coreclientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+
+	"github.com/sundi0331/logbook/config"
+)
+
+type leaderElectionClients struct {
+	core         coreclientv1.CoreV1Interface
+	coordination v1.CoordinationV1Interface
+}
+
+func runWithLeaderElection(ctx context.Context, cfg config.LeaderElectionConfig, clients leaderElectionClients, logger *slog.Logger, run func(context.Context) error) error {
+	if !cfg.Enabled {
+		return run(ctx)
+	}
+
+	identity, err := leaderElectionIdentity(cfg)
+	if err != nil {
+		return err
+	}
+	namespace := leaderElectionNamespace(cfg)
+	name := cfg.Name
+
+	lock, err := resourcelock.New(
+		resourcelock.LeasesResourceLock,
+		namespace,
+		name,
+		clients.core,
+		clients.coordination,
+		resourcelock.ResourceLockConfig{Identity: identity},
+	)
+	if err != nil {
+		return fmt.Errorf("create leader election lock: %w", err)
+	}
+
+	timing, err := leaderElectionTiming(cfg)
+	if err != nil {
+		return err
+	}
+
+	electionCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	runStarted := make(chan struct{}, 1)
+	runDone := make(chan error, 1)
+	leaderConfig := leaderelection.LeaderElectionConfig{
+		Lock:          lock,
+		LeaseDuration: timing.leaseDuration,
+		RenewDeadline: timing.renewDeadline,
+		RetryPeriod:   timing.retryPeriod,
+		Callbacks: leaderelection.LeaderCallbacks{
+			OnStartedLeading: func(leaderCtx context.Context) {
+				logger.Info("acquired leader election lease", "leader_identity", identity, "lease_namespace", namespace, "lease_name", name)
+				select {
+				case runStarted <- struct{}{}:
+				default:
+				}
+				err := run(leaderCtx)
+				runDone <- err
+				cancel()
+			},
+			OnStoppedLeading: func() {
+				logger.Info("stopped leading", "leader_identity", identity, "lease_namespace", namespace, "lease_name", name)
+			},
+			OnNewLeader: func(current string) {
+				if current == identity {
+					return
+				}
+				logger.Info("observed leader election holder", "leader_identity", current, "lease_namespace", namespace, "lease_name", name)
+			},
+		},
+		Name: name,
+	}
+
+	leader, err := leaderelection.NewLeaderElector(leaderConfig)
+	if err != nil {
+		return fmt.Errorf("configure leader election: %w", err)
+	}
+	leader.Run(electionCtx)
+
+	select {
+	case <-runStarted:
+		return <-runDone
+	default:
+		return nil
+	}
+}
+
+type leaderElectionDurations struct {
+	leaseDuration time.Duration
+	renewDeadline time.Duration
+	retryPeriod   time.Duration
+}
+
+func leaderElectionTiming(cfg config.LeaderElectionConfig) (leaderElectionDurations, error) {
+	leaseDuration, err := parseDuration("leader election lease duration", cfg.LeaseDuration)
+	if err != nil {
+		return leaderElectionDurations{}, err
+	}
+	renewDeadline, err := parseDuration("leader election renew deadline", cfg.RenewDeadline)
+	if err != nil {
+		return leaderElectionDurations{}, err
+	}
+	retryPeriod, err := parseDuration("leader election retry period", cfg.RetryPeriod)
+	if err != nil {
+		return leaderElectionDurations{}, err
+	}
+	return leaderElectionDurations{
+		leaseDuration: leaseDuration,
+		renewDeadline: renewDeadline,
+		retryPeriod:   retryPeriod,
+	}, nil
+}
+
+func parseDuration(name, value string) (time.Duration, error) {
+	duration, err := time.ParseDuration(value)
+	if err != nil {
+		return 0, fmt.Errorf("parse %s %q: %w", name, value, err)
+	}
+	return duration, nil
+}
+
+func leaderElectionIdentity(cfg config.LeaderElectionConfig) (string, error) {
+	if cfg.Identity != "" {
+		return cfg.Identity, nil
+	}
+	if podName := os.Getenv("POD_NAME"); podName != "" {
+		return podName, nil
+	}
+	hostname, err := os.Hostname()
+	if err != nil {
+		return "", fmt.Errorf("resolve leader election identity: %w", err)
+	}
+	if hostname == "" {
+		return "", fmt.Errorf("resolve leader election identity: hostname is empty")
+	}
+	return hostname, nil
+}
+
+func leaderElectionNamespace(cfg config.LeaderElectionConfig) string {
+	if cfg.Namespace != "" {
+		return cfg.Namespace
+	}
+	if podNamespace := os.Getenv("POD_NAMESPACE"); podNamespace != "" {
+		return podNamespace
+	}
+	return "default"
+}

--- a/app/root.go
+++ b/app/root.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -12,9 +13,12 @@ import (
 	"time"
 
 	eventsv1 "k8s.io/api/events/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
+	coordinationclientv1 "k8s.io/client-go/kubernetes/typed/coordination/v1"
+	coreclientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	eventclientv1 "k8s.io/client-go/kubernetes/typed/events/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -22,7 +26,12 @@ import (
 	"github.com/sundi0331/logbook/config"
 )
 
-const retryDelay = 5 * time.Second
+const (
+	retryDelay             = 5 * time.Second
+	checkpointFlushTimeout = 10 * time.Second
+)
+
+var errResourceVersionExpired = errors.New("Kubernetes event resource version expired")
 
 type eventWatcher interface {
 	List(ctx context.Context, opts metav1.ListOptions) (*eventsv1.EventList, error)
@@ -33,18 +42,75 @@ func Run(parent context.Context, cfg *config.Config, logger *slog.Logger) error 
 	ctx, stop := signal.NotifyContext(parent, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
 	defer stop()
 
-	client, err := createEventsClient(&cfg.Auth, logger)
+	restConfig, err := createRESTConfig(&cfg.Auth, logger)
+	if err != nil {
+		return err
+	}
+
+	eventsClient, err := eventclientv1.NewForConfig(restConfig)
 	if err != nil {
 		return fmt.Errorf("create Kubernetes events client: %w", err)
 	}
 
-	return watchEvents(ctx, cfg, client.Events(cfg.Target.Namespace), logger)
+	var coreClient *coreclientv1.CoreV1Client
+	if needsCoreClient(cfg) {
+		coreClient, err = coreclientv1.NewForConfig(restConfig)
+		if err != nil {
+			return fmt.Errorf("create Kubernetes core client: %w", err)
+		}
+	}
+	checkpoint, err := newCheckpointStore(cfg.Checkpoint, coreClient)
+	if err != nil {
+		return fmt.Errorf("create checkpoint store: %w", err)
+	}
+
+	flushInterval := time.Duration(0)
+	if checkpoint != nil {
+		flushInterval, err = checkpointFlushInterval(cfg.Checkpoint)
+		if err != nil {
+			return err
+		}
+	}
+
+	leaderClients := leaderElectionClients{}
+	if cfg.LeaderElection.Enabled {
+		coordinationClient, err := coordinationclientv1.NewForConfig(restConfig)
+		if err != nil {
+			return fmt.Errorf("create Kubernetes coordination client: %w", err)
+		}
+		leaderClients = leaderElectionClients{core: coreClient, coordination: coordinationClient}
+	}
+
+	return runWithLeaderElection(
+		ctx,
+		cfg.LeaderElection,
+		leaderClients,
+		logger,
+		func(leaderCtx context.Context) error {
+			return watchEvents(leaderCtx, cfg, eventsClient.Events(cfg.Target.Namespace), checkpoint, flushInterval, logger)
+		},
+	)
 }
 
-func watchEvents(ctx context.Context, cfg *config.Config, events eventWatcher, logger *slog.Logger) error {
-	logger.Info("starting Kubernetes event watcher", "api_group", "events.k8s.io", "api_version", "v1", "namespace", namespaceLabel(cfg.Target.Namespace))
+func needsCoreClient(cfg *config.Config) bool {
+	return cfg.LeaderElection.Enabled || (cfg.Checkpoint.Enabled && cfg.Checkpoint.Backend == "configmap")
+}
+
+func watchEvents(ctx context.Context, cfg *config.Config, events eventWatcher, checkpoint checkpointStore, checkpointFlushInterval time.Duration, logger *slog.Logger) error {
+	logger.Info("starting Kubernetes event watcher", "api_group", "events.k8s.io", "api_version", "v1", "namespace", namespaceLabel(cfg.Target.Namespace), "checkpoint_enabled", cfg.Checkpoint.Enabled, "checkpoint_backend", cfg.Checkpoint.Backend, "checkpoint_flush_interval", checkpointFlushInterval.String())
 
 	options := cfg.Target.ListOptions
+	if checkpoint != nil {
+		resourceVersion, err := checkpoint.Load(ctx)
+		if err != nil {
+			return fmt.Errorf("load checkpoint: %w", err)
+		}
+		if resourceVersion != "" {
+			options.ResourceVersion = resourceVersion
+			logger.Info("loaded Kubernetes event checkpoint", "resource_version", resourceVersion)
+		}
+	}
+
 	for {
 		if options.ResourceVersion == "" {
 			resourceVersion, err := currentResourceVersion(ctx, events, options, logger)
@@ -59,12 +125,28 @@ func watchEvents(ctx context.Context, cfg *config.Config, events eventWatcher, l
 				continue
 			}
 			options.ResourceVersion = resourceVersion
+			if checkpoint != nil {
+				if err := checkpoint.Save(ctx, resourceVersion); err != nil {
+					return fmt.Errorf("save initialized checkpoint: %w", err)
+				}
+				if err := checkpoint.Flush(ctx); err != nil {
+					return fmt.Errorf("flush initialized checkpoint: %w", err)
+				}
+			}
 		}
 
 		watcher, err := events.Watch(ctx, options)
 		if err != nil {
 			if ctx.Err() != nil {
 				return nil
+			}
+			if apierrors.IsResourceExpired(err) {
+				resourceVersion, err := recoverExpiredResourceVersion(ctx, cfg, events, checkpoint, logger)
+				if err != nil {
+					return err
+				}
+				options.ResourceVersion = resourceVersion
+				continue
 			}
 			logger.Error("failed to start event watch", "error", err, "retry_after", retryDelay.String())
 			if err := waitForRetry(ctx); err != nil {
@@ -73,9 +155,17 @@ func watchEvents(ctx context.Context, cfg *config.Config, events eventWatcher, l
 			continue
 		}
 
-		resourceVersion, err := consumeEvents(ctx, watcher, logger)
+		resourceVersion, err := consumeEvents(ctx, watcher, checkpoint, checkpointFlushInterval, logger)
 		watcher.Stop()
 		if err != nil {
+			if errors.Is(err, errResourceVersionExpired) {
+				resourceVersion, err := recoverExpiredResourceVersion(ctx, cfg, events, checkpoint, logger)
+				if err != nil {
+					return err
+				}
+				options.ResourceVersion = resourceVersion
+				continue
+			}
 			return err
 		}
 		if resourceVersion != "" {
@@ -89,16 +179,50 @@ func watchEvents(ctx context.Context, cfg *config.Config, events eventWatcher, l
 	}
 }
 
-func consumeEvents(ctx context.Context, watcher watch.Interface, logger *slog.Logger) (string, error) {
+func consumeEvents(ctx context.Context, watcher watch.Interface, checkpoint checkpointStore, checkpointFlushInterval time.Duration, logger *slog.Logger) (string, error) {
 	resourceVersion := ""
+	var checkpointTicker *time.Ticker
+	var checkpointTicks <-chan time.Time
+	if checkpoint != nil && checkpointFlushInterval > 0 {
+		checkpointTicker = time.NewTicker(checkpointFlushInterval)
+		defer checkpointTicker.Stop()
+		checkpointTicks = checkpointTicker.C
+	}
+
+	flushCheckpoint := func() error {
+		if checkpoint == nil {
+			return nil
+		}
+		flushCtx, cancel := context.WithTimeout(context.Background(), checkpointFlushTimeout)
+		defer cancel()
+		if err := checkpoint.Flush(flushCtx); err != nil {
+			return fmt.Errorf("flush checkpoint: %w", err)
+		}
+		return nil
+	}
+
 	for {
 		select {
 		case <-ctx.Done():
 			logger.Info("shutdown signal received; stopping event watcher")
-			return resourceVersion, nil
+			return resourceVersion, flushCheckpoint()
+		case <-checkpointTicks:
+			if err := flushCheckpoint(); err != nil {
+				return resourceVersion, err
+			}
 		case event, ok := <-watcher.ResultChan():
 			if !ok {
-				return resourceVersion, nil
+				return resourceVersion, flushCheckpoint()
+			}
+			if event.Type == watch.Error {
+				if apierrors.IsResourceExpired(apierrors.FromObject(event.Object)) {
+					return resourceVersion, errResourceVersionExpired
+				}
+				marshalledEvent, err := json.Marshal(event)
+				if err != nil {
+					return resourceVersion, fmt.Errorf("marshal Kubernetes watch error event: %w", err)
+				}
+				return resourceVersion, fmt.Errorf("Kubernetes watch error event: %s", string(marshalledEvent))
 			}
 			if event.Object != nil {
 				accessor, err := meta.Accessor(event.Object)
@@ -112,7 +236,39 @@ func consumeEvents(ctx context.Context, watcher watch.Interface, logger *slog.Lo
 				return resourceVersion, fmt.Errorf("marshal Kubernetes watch event: %w", err)
 			}
 			logger.Info("kubernetes event observed", "watch_type", string(event.Type), "event", json.RawMessage(marshalledEvent), "resource_version", resourceVersion)
+			if checkpoint != nil && resourceVersion != "" {
+				if err := checkpoint.Save(ctx, resourceVersion); err != nil {
+					return resourceVersion, fmt.Errorf("save checkpoint: %w", err)
+				}
+			}
 		}
+	}
+}
+
+func recoverExpiredResourceVersion(ctx context.Context, cfg *config.Config, events eventWatcher, checkpoint checkpointStore, logger *slog.Logger) (string, error) {
+	switch cfg.Checkpoint.OnExpiredResourceVersion {
+	case "skip-existing":
+		logger.Warn("Kubernetes event resource version expired; advancing checkpoint to current resource version")
+		resourceVersion, err := currentResourceVersion(ctx, events, cfg.Target.ListOptions, logger)
+		if err != nil {
+			if ctx.Err() != nil {
+				return "", nil
+			}
+			return "", fmt.Errorf("recover expired resource version: %w", err)
+		}
+		if checkpoint != nil {
+			if err := checkpoint.Save(ctx, resourceVersion); err != nil {
+				return "", fmt.Errorf("save recovered checkpoint: %w", err)
+			}
+			if err := checkpoint.Flush(ctx); err != nil {
+				return "", fmt.Errorf("flush recovered checkpoint: %w", err)
+			}
+		}
+		return resourceVersion, nil
+	case "fail":
+		return "", errResourceVersionExpired
+	default:
+		return "", fmt.Errorf("unsupported checkpoint expiration policy %q: expected skip-existing or fail", cfg.Checkpoint.OnExpiredResourceVersion)
 	}
 }
 
@@ -134,14 +290,6 @@ func waitForRetry(ctx context.Context) error {
 	case <-timer.C:
 		return nil
 	}
-}
-
-func createEventsClient(authCfg *config.AuthConfig, logger *slog.Logger) (*eventclientv1.EventsV1Client, error) {
-	restConfig, err := createRESTConfig(authCfg, logger)
-	if err != nil {
-		return nil, err
-	}
-	return eventclientv1.NewForConfig(restConfig)
 }
 
 func createRESTConfig(authCfg *config.AuthConfig, logger *slog.Logger) (*rest.Config, error) {

--- a/app/root_test.go
+++ b/app/root_test.go
@@ -3,13 +3,22 @@ package app
 import (
 	"bytes"
 	"context"
+	"errors"
 	"log/slog"
+	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	eventsv1 "k8s.io/api/events/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/sundi0331/logbook/config"
 )
 
 type staticEventWatcher struct {
@@ -22,6 +31,25 @@ func (s staticEventWatcher) List(context.Context, metav1.ListOptions) (*eventsv1
 
 func (staticEventWatcher) Watch(context.Context, metav1.ListOptions) (watch.Interface, error) {
 	return watch.NewFake(), nil
+}
+
+type memoryCheckpointStore struct {
+	resourceVersion string
+	saveCount       int
+}
+
+func (s *memoryCheckpointStore) Load(context.Context) (string, error) {
+	return s.resourceVersion, nil
+}
+
+func (s *memoryCheckpointStore) Save(_ context.Context, resourceVersion string) error {
+	s.resourceVersion = resourceVersion
+	s.saveCount++
+	return nil
+}
+
+func (s *memoryCheckpointStore) Flush(context.Context) error {
+	return nil
 }
 
 func TestCurrentResourceVersionReturnsListVersion(t *testing.T) {
@@ -61,12 +89,16 @@ func TestConsumeEventsLogsObservedEvent(t *testing.T) {
 		watcher.Stop()
 	}()
 
-	resourceVersion, err := consumeEvents(context.Background(), watcher, logger)
+	checkpoint := &memoryCheckpointStore{}
+	resourceVersion, err := consumeEvents(context.Background(), watcher, checkpoint, 0, logger)
 	if err != nil {
 		t.Fatalf("consumeEvents() error = %v", err)
 	}
 	if resourceVersion != "456" {
 		t.Fatalf("consumeEvents() resourceVersion = %q, want 456", resourceVersion)
+	}
+	if checkpoint.resourceVersion != "456" {
+		t.Fatalf("checkpoint resourceVersion = %q, want 456", checkpoint.resourceVersion)
 	}
 
 	logged := output.String()
@@ -75,5 +107,393 @@ func TestConsumeEventsLogsObservedEvent(t *testing.T) {
 	}
 	if !strings.Contains(logged, "SmokeTest") {
 		t.Fatalf("consumeEvents() log = %q, want event reason", logged)
+	}
+}
+
+func TestConsumeEventsReturnsExpiredResourceVersionError(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))
+	watcher := watch.NewFake()
+
+	go func() {
+		watcher.Error(&metav1.Status{
+			Status: metav1.StatusFailure,
+			Reason: metav1.StatusReasonExpired,
+			Code:   http.StatusGone,
+		})
+		watcher.Stop()
+	}()
+
+	_, err := consumeEvents(context.Background(), watcher, nil, 0, logger)
+	if !errors.Is(err, errResourceVersionExpired) {
+		t.Fatalf("consumeEvents() error = %v, want errResourceVersionExpired", err)
+	}
+}
+
+func TestRecoverExpiredResourceVersionSkipsExistingAndSavesCheckpoint(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))
+	events := staticEventWatcher{
+		list: &eventsv1.EventList{
+			ListMeta: metav1.ListMeta{ResourceVersion: "789"},
+		},
+	}
+	checkpoint := &memoryCheckpointStore{}
+	cfg := &config.Config{
+		Checkpoint: config.CheckpointConfig{OnExpiredResourceVersion: "skip-existing"},
+	}
+
+	resourceVersion, err := recoverExpiredResourceVersion(context.Background(), cfg, events, checkpoint, logger)
+	if err != nil {
+		t.Fatalf("recoverExpiredResourceVersion() error = %v", err)
+	}
+	if resourceVersion != "789" {
+		t.Fatalf("recoverExpiredResourceVersion() = %q, want 789", resourceVersion)
+	}
+	if checkpoint.resourceVersion != "789" {
+		t.Fatalf("checkpoint resourceVersion = %q, want 789", checkpoint.resourceVersion)
+	}
+}
+
+func TestRecoverExpiredResourceVersionFailPolicy(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))
+	cfg := &config.Config{
+		Checkpoint: config.CheckpointConfig{OnExpiredResourceVersion: "fail"},
+	}
+
+	_, err := recoverExpiredResourceVersion(context.Background(), cfg, staticEventWatcher{}, nil, logger)
+	if !errors.Is(err, errResourceVersionExpired) {
+		t.Fatalf("recoverExpiredResourceVersion() error = %v, want errResourceVersionExpired", err)
+	}
+}
+
+func TestConsumeEventsReturnsNonExpiredWatchError(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))
+	watcher := watch.NewFake()
+
+	go func() {
+		watcher.Error(&metav1.Status{
+			Status: metav1.StatusFailure,
+			Reason: metav1.StatusReasonNotFound,
+			Code:   http.StatusNotFound,
+		})
+		watcher.Stop()
+	}()
+
+	_, err := consumeEvents(context.Background(), watcher, nil, 0, logger)
+	if err == nil {
+		t.Fatal("consumeEvents() error = nil, want error")
+	}
+	if errors.Is(err, errResourceVersionExpired) {
+		t.Fatalf("consumeEvents() error = %v, did not want errResourceVersionExpired", err)
+	}
+}
+
+func TestBufferedCheckpointStoreCoalescesSavesUntilFlush(t *testing.T) {
+	base := &memoryCheckpointStore{}
+	checkpoint := newBufferedCheckpointStore(base)
+
+	if err := checkpoint.Save(context.Background(), "100"); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+	if err := checkpoint.Save(context.Background(), "101"); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+	if base.saveCount != 0 {
+		t.Fatalf("base saveCount = %d, want 0 before flush", base.saveCount)
+	}
+
+	if err := checkpoint.Flush(context.Background()); err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+	if base.resourceVersion != "101" {
+		t.Fatalf("base resourceVersion = %q, want 101", base.resourceVersion)
+	}
+	if base.saveCount != 1 {
+		t.Fatalf("base saveCount = %d, want 1", base.saveCount)
+	}
+
+	if err := checkpoint.Flush(context.Background()); err != nil {
+		t.Fatalf("second Flush() error = %v", err)
+	}
+	if base.saveCount != 1 {
+		t.Fatalf("base saveCount after second flush = %d, want 1", base.saveCount)
+	}
+}
+
+func TestConsumeEventsFlushesBufferedCheckpointOnClose(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))
+	base := &memoryCheckpointStore{}
+	checkpoint := newBufferedCheckpointStore(base)
+	watcher := watch.NewFake()
+
+	go func() {
+		watcher.Add(&eventsv1.Event{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "checkpoint-event",
+				ResourceVersion: "900",
+			},
+		})
+		watcher.Stop()
+	}()
+
+	resourceVersion, err := consumeEvents(context.Background(), watcher, checkpoint, time.Hour, logger)
+	if err != nil {
+		t.Fatalf("consumeEvents() error = %v", err)
+	}
+	if resourceVersion != "900" {
+		t.Fatalf("consumeEvents() resourceVersion = %q, want 900", resourceVersion)
+	}
+	if base.resourceVersion != "900" {
+		t.Fatalf("base resourceVersion = %q, want 900", base.resourceVersion)
+	}
+	if base.saveCount != 1 {
+		t.Fatalf("base saveCount = %d, want 1", base.saveCount)
+	}
+}
+
+func TestCheckpointDisabledIgnoresInvalidFlushInterval(t *testing.T) {
+	store, err := newCheckpointStore(config.CheckpointConfig{
+		Enabled:       false,
+		FlushInterval: "not-a-duration",
+	}, nil)
+	if err != nil {
+		t.Fatalf("newCheckpointStore() error = %v", err)
+	}
+	if store != nil {
+		t.Fatalf("newCheckpointStore() = %T, want nil", store)
+	}
+}
+
+func TestFileCheckpointStoreLoadTrimsWhitespace(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "checkpoint")
+	if err := os.WriteFile(path, []byte("12345\n"), 0o640); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	resourceVersion, err := newFileCheckpointStore(path).Load(context.Background())
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if resourceVersion != "12345" {
+		t.Fatalf("Load() = %q, want 12345", resourceVersion)
+	}
+}
+
+func TestConfigMapCheckpointStoreCreatesBeforePatchWhenMissing(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	store := newConfigMapCheckpointStore(client.CoreV1().ConfigMaps("default"), "logbook-checkpoint")
+
+	if err := store.Save(context.Background(), "123"); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	actions := client.Actions()
+	if len(actions) != 1 {
+		t.Fatalf("actions = %#v, want exactly one create action", actions)
+	}
+	if action := actions[0].GetVerb(); action != "create" {
+		t.Fatalf("first action = %q, want create", action)
+	}
+}
+
+func TestConfigMapCheckpointStorePatchesAfterLoad(t *testing.T) {
+	client := fake.NewSimpleClientset(&corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "logbook-checkpoint", Namespace: "default"},
+		Data:       map[string]string{checkpointResourceVersionKey: "100"},
+	})
+	store := newConfigMapCheckpointStore(client.CoreV1().ConfigMaps("default"), "logbook-checkpoint")
+
+	if _, err := store.Load(context.Background()); err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	client.ClearActions()
+
+	if err := store.Save(context.Background(), "101"); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	actions := client.Actions()
+	if len(actions) != 1 {
+		t.Fatalf("actions = %#v, want exactly one patch action", actions)
+	}
+	if action := actions[0].GetVerb(); action != "patch" {
+		t.Fatalf("first action = %q, want patch", action)
+	}
+}
+
+func TestLeaderElectionDisabledIgnoresInvalidTiming(t *testing.T) {
+	called := false
+	err := runWithLeaderElection(context.Background(), config.LeaderElectionConfig{
+		Enabled:       false,
+		LeaseDuration: "not-a-duration",
+	}, leaderElectionClients{}, slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil)), func(context.Context) error {
+		called = true
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("runWithLeaderElection() error = %v", err)
+	}
+	if !called {
+		t.Fatal("runWithLeaderElection() did not call run function")
+	}
+}
+
+func TestLeaderElectionTimingParsesDurations(t *testing.T) {
+	timing, err := leaderElectionTiming(config.LeaderElectionConfig{
+		LeaseDuration: "15s",
+		RenewDeadline: "10s",
+		RetryPeriod:   "2s",
+	})
+	if err != nil {
+		t.Fatalf("leaderElectionTiming() error = %v", err)
+	}
+	if timing.leaseDuration != 15*time.Second {
+		t.Fatalf("leaseDuration = %s, want 15s", timing.leaseDuration)
+	}
+	if timing.renewDeadline != 10*time.Second {
+		t.Fatalf("renewDeadline = %s, want 10s", timing.renewDeadline)
+	}
+	if timing.retryPeriod != 2*time.Second {
+		t.Fatalf("retryPeriod = %s, want 2s", timing.retryPeriod)
+	}
+}
+
+func TestLeaderElectionIdentityUsesConfiguredIdentity(t *testing.T) {
+	identity, err := leaderElectionIdentity(config.LeaderElectionConfig{Identity: "configured"})
+	if err != nil {
+		t.Fatalf("leaderElectionIdentity() error = %v", err)
+	}
+	if identity != "configured" {
+		t.Fatalf("leaderElectionIdentity() = %q, want configured", identity)
+	}
+}
+
+func TestLeaderElectionIdentityUsesPodName(t *testing.T) {
+	t.Setenv("POD_NAME", "pod-identity")
+
+	identity, err := leaderElectionIdentity(config.LeaderElectionConfig{})
+	if err != nil {
+		t.Fatalf("leaderElectionIdentity() error = %v", err)
+	}
+	if identity != "pod-identity" {
+		t.Fatalf("leaderElectionIdentity() = %q, want pod-identity", identity)
+	}
+}
+
+func TestLeaderElectionNamespaceFallback(t *testing.T) {
+	if namespace := leaderElectionNamespace(config.LeaderElectionConfig{Namespace: "configured"}); namespace != "configured" {
+		t.Fatalf("configured namespace = %q, want configured", namespace)
+	}
+
+	t.Setenv("POD_NAMESPACE", "pod-namespace")
+	if namespace := leaderElectionNamespace(config.LeaderElectionConfig{}); namespace != "pod-namespace" {
+		t.Fatalf("POD_NAMESPACE namespace = %q, want pod-namespace", namespace)
+	}
+
+	t.Setenv("POD_NAMESPACE", "")
+	if namespace := leaderElectionNamespace(config.LeaderElectionConfig{}); namespace != "default" {
+		t.Fatalf("default namespace = %q, want default", namespace)
+	}
+}
+
+func TestLeaderElectionEnabledValidatesTimingBeforeRunning(t *testing.T) {
+	err := runWithLeaderElection(context.Background(), config.LeaderElectionConfig{
+		Enabled:       true,
+		Name:          "logbook-leader",
+		Identity:      "test-identity",
+		LeaseDuration: "invalid",
+		RenewDeadline: "10s",
+		RetryPeriod:   "2s",
+	}, leaderElectionClients{}, slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil)), func(context.Context) error {
+		t.Fatal("run function should not be called with invalid leader election timing")
+		return nil
+	})
+	if err == nil {
+		t.Fatal("runWithLeaderElection() error = nil, want error")
+	}
+}
+
+func TestLeaderElectionWaitsForRunCallbackAfterContextCancel(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	started := make(chan struct{})
+	finished := make(chan struct{})
+	returned := make(chan error, 1)
+
+	go func() {
+		returned <- runWithLeaderElection(ctx, config.LeaderElectionConfig{
+			Enabled:       true,
+			Namespace:     "default",
+			Name:          "logbook-leader",
+			Identity:      "test-identity",
+			LeaseDuration: "2s",
+			RenewDeadline: "1500ms",
+			RetryPeriod:   "100ms",
+		}, leaderElectionClients{
+			core:         client.CoreV1(),
+			coordination: client.CoordinationV1(),
+		}, slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil)), func(runCtx context.Context) error {
+			close(started)
+			cancel()
+			<-runCtx.Done()
+			time.Sleep(100 * time.Millisecond)
+			close(finished)
+			return nil
+		})
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("leader election run callback did not start")
+	}
+
+	select {
+	case err := <-returned:
+		t.Fatalf("runWithLeaderElection() returned before callback finished: %v", err)
+	case <-finished:
+	case <-time.After(2 * time.Second):
+		t.Fatal("leader election run callback did not finish")
+	}
+
+	select {
+	case err := <-returned:
+		if err != nil {
+			t.Fatalf("runWithLeaderElection() error = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("runWithLeaderElection() did not return after callback finished")
+	}
+}
+
+func TestLeaderElectionStopsWhenRunCallbackReturnsNil(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	returned := make(chan error, 1)
+
+	go func() {
+		returned <- runWithLeaderElection(context.Background(), config.LeaderElectionConfig{
+			Enabled:       true,
+			Namespace:     "default",
+			Name:          "logbook-leader",
+			Identity:      "test-identity",
+			LeaseDuration: "2s",
+			RenewDeadline: "1500ms",
+			RetryPeriod:   "100ms",
+		}, leaderElectionClients{
+			core:         client.CoreV1(),
+			coordination: client.CoordinationV1(),
+		}, slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil)), func(context.Context) error {
+			return nil
+		})
+	}()
+
+	select {
+	case err := <-returned:
+		if err != nil {
+			t.Fatalf("runWithLeaderElection() error = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("runWithLeaderElection() did not return after callback returned nil")
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -50,6 +50,20 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&cfg.Log.Out, "log-out", "", "log output: stdout, stderr, or file (default is stdout)")
 	rootCmd.PersistentFlags().StringVar(&cfg.Log.Level, "log-level", "", "log level: debug, info, warn, or error (default is info)")
 	rootCmd.PersistentFlags().StringVar(&cfg.Log.Filename, "log-filename", "", "full path of log file with filename (valid only when log-out is set to file; default is k8s-events.log)")
+	rootCmd.PersistentFlags().BoolVar(&cfg.Checkpoint.Enabled, "checkpoint-enabled", true, "enable Kubernetes event resource version checkpointing (default is true)")
+	rootCmd.PersistentFlags().StringVar(&cfg.Checkpoint.Backend, "checkpoint-backend", "", "checkpoint backend: configmap or file (default is configmap)")
+	rootCmd.PersistentFlags().StringVar(&cfg.Checkpoint.Namespace, "checkpoint-namespace", "", "namespace for the checkpoint ConfigMap (default is POD_NAMESPACE or default)")
+	rootCmd.PersistentFlags().StringVar(&cfg.Checkpoint.Name, "checkpoint-name", "", "name of the checkpoint ConfigMap (default is logbook-checkpoint)")
+	rootCmd.PersistentFlags().StringVar(&cfg.Checkpoint.Path, "checkpoint-path", "", "path for file checkpoint backend (default is logbook-checkpoint)")
+	rootCmd.PersistentFlags().StringVar(&cfg.Checkpoint.FlushInterval, "checkpoint-flush-interval", "", "checkpoint flush interval; set to 0s to flush every event (default is 5s)")
+	rootCmd.PersistentFlags().StringVar(&cfg.Checkpoint.OnExpiredResourceVersion, "checkpoint-on-expired-resource-version", "", "behavior when a checkpoint resource version expires: skip-existing or fail (default is skip-existing)")
+	rootCmd.PersistentFlags().BoolVar(&cfg.LeaderElection.Enabled, "leader-election-enabled", false, "enable Kubernetes Lease leader election (default is false)")
+	rootCmd.PersistentFlags().StringVar(&cfg.LeaderElection.Namespace, "leader-election-namespace", "", "namespace for the leader election Lease (default is POD_NAMESPACE or default)")
+	rootCmd.PersistentFlags().StringVar(&cfg.LeaderElection.Name, "leader-election-name", "", "name of the leader election Lease (default is logbook-leader)")
+	rootCmd.PersistentFlags().StringVar(&cfg.LeaderElection.Identity, "leader-election-identity", "", "identity for this leader election candidate (default is POD_NAME or hostname)")
+	rootCmd.PersistentFlags().StringVar(&cfg.LeaderElection.LeaseDuration, "leader-election-lease-duration", "", "leader election lease duration (default is 15s)")
+	rootCmd.PersistentFlags().StringVar(&cfg.LeaderElection.RenewDeadline, "leader-election-renew-deadline", "", "leader election renew deadline (default is 10s)")
+	rootCmd.PersistentFlags().StringVar(&cfg.LeaderElection.RetryPeriod, "leader-election-retry-period", "", "leader election retry period (default is 2s)")
 
 	mustBindPFlag("config", "config")
 	mustBindPFlag("auth.mode", "mode")
@@ -59,6 +73,20 @@ func init() {
 	mustBindPFlag("log.out", "log-out")
 	mustBindPFlag("log.level", "log-level")
 	mustBindPFlag("log.filename", "log-filename")
+	mustBindPFlag("checkpoint.enabled", "checkpoint-enabled")
+	mustBindPFlag("checkpoint.backend", "checkpoint-backend")
+	mustBindPFlag("checkpoint.namespace", "checkpoint-namespace")
+	mustBindPFlag("checkpoint.name", "checkpoint-name")
+	mustBindPFlag("checkpoint.path", "checkpoint-path")
+	mustBindPFlag("checkpoint.flush_interval", "checkpoint-flush-interval")
+	mustBindPFlag("checkpoint.on_expired_resource_version", "checkpoint-on-expired-resource-version")
+	mustBindPFlag("leader_election.enabled", "leader-election-enabled")
+	mustBindPFlag("leader_election.namespace", "leader-election-namespace")
+	mustBindPFlag("leader_election.name", "leader-election-name")
+	mustBindPFlag("leader_election.identity", "leader-election-identity")
+	mustBindPFlag("leader_election.lease_duration", "leader-election-lease-duration")
+	mustBindPFlag("leader_election.renew_deadline", "leader-election-renew-deadline")
+	mustBindPFlag("leader_election.retry_period", "leader-election-retry-period")
 }
 
 func mustBindPFlag(key, flag string) {
@@ -94,7 +122,7 @@ func initialize() (*slog.Logger, func() error, error) {
 	if viper.ConfigFileUsed() != "" {
 		logger.Info("using config file", "path", viper.ConfigFileUsed())
 	}
-	logger.Info("initialized configuration", "auth_mode", cfg.Auth.Mode, "target_namespace", cfg.Target.Namespace, "log_format", cfg.Log.Format, "log_output", cfg.Log.Out, "log_level", cfg.Log.Level)
+	logger.Info("initialized configuration", "auth_mode", cfg.Auth.Mode, "target_namespace", cfg.Target.Namespace, "log_format", cfg.Log.Format, "log_output", cfg.Log.Out, "log_level", cfg.Log.Level, "checkpoint_enabled", cfg.Checkpoint.Enabled, "checkpoint_backend", cfg.Checkpoint.Backend, "checkpoint_namespace", cfg.Checkpoint.Namespace, "checkpoint_flush_interval", cfg.Checkpoint.FlushInterval, "leader_election_enabled", cfg.LeaderElection.Enabled, "leader_election_namespace", cfg.LeaderElection.Namespace, "leader_election_name", cfg.LeaderElection.Name)
 
 	return logger, cleanup, nil
 }
@@ -106,6 +134,20 @@ func setDefaults() {
 	viper.SetDefault("log.filename", "k8s-events.log")
 	viper.SetDefault("log.level", "info")
 	viper.SetDefault("auth.mode", "in-cluster")
+	viper.SetDefault("checkpoint.enabled", true)
+	viper.SetDefault("checkpoint.backend", "configmap")
+	viper.SetDefault("checkpoint.namespace", "")
+	viper.SetDefault("checkpoint.name", "logbook-checkpoint")
+	viper.SetDefault("checkpoint.path", "logbook-checkpoint")
+	viper.SetDefault("checkpoint.flush_interval", "5s")
+	viper.SetDefault("checkpoint.on_expired_resource_version", "skip-existing")
+	viper.SetDefault("leader_election.enabled", false)
+	viper.SetDefault("leader_election.namespace", "")
+	viper.SetDefault("leader_election.name", "logbook-leader")
+	viper.SetDefault("leader_election.identity", "")
+	viper.SetDefault("leader_election.lease_duration", "15s")
+	viper.SetDefault("leader_election.renew_deadline", "10s")
+	viper.SetDefault("leader_election.retry_period", "2s")
 }
 
 func configureFileLookup() {

--- a/config/config.go
+++ b/config/config.go
@@ -20,8 +20,30 @@ type AuthConfig struct {
 	KubeConfig string
 }
 
+type CheckpointConfig struct {
+	Enabled                  bool
+	Backend                  string
+	Namespace                string
+	Name                     string
+	Path                     string
+	FlushInterval            string `mapstructure:"flush_interval"`
+	OnExpiredResourceVersion string `mapstructure:"on_expired_resource_version"`
+}
+
+type LeaderElectionConfig struct {
+	Enabled       bool
+	Namespace     string
+	Name          string
+	Identity      string
+	LeaseDuration string `mapstructure:"lease_duration"`
+	RenewDeadline string `mapstructure:"renew_deadline"`
+	RetryPeriod   string `mapstructure:"retry_period"`
+}
+
 type Config struct {
-	Log    LogConfig
-	Target TargetConfig
-	Auth   AuthConfig
+	Log            LogConfig
+	Target         TargetConfig
+	Auth           AuthConfig
+	Checkpoint     CheckpointConfig
+	LeaderElection LeaderElectionConfig `mapstructure:"leader_election"`
 }

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/sagikazarmark/locafero v0.11.0 // indirect
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 // indirect
 	github.com/spf13/afero v1.15.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -92,6 +92,8 @@ github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.yaml.in/yaml/v2 v2.4.3 h1:6gvOSjQoTB3vt1l+CU+tSyi/HOjfOjRLJ4YwYZGwRO0=
 go.yaml.in/yaml/v2 v2.4.3/go.mod h1:zSxWcmIDjOzPXpjlTTbAsKokqkDNAVtZO0WOMiT90s8=
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=

--- a/helmchart/templates/_helpers.tpl
+++ b/helmchart/templates/_helpers.tpl
@@ -60,3 +60,45 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Create the checkpoint ConfigMap name.
+*/}}
+{{- define "logbook.checkpointName" -}}
+{{- default "logbook-checkpoint" .Values.logbook.checkpoint.name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create the checkpoint ConfigMap namespace.
+*/}}
+{{- define "logbook.checkpointNamespace" -}}
+{{- default .Release.Namespace .Values.logbook.checkpoint.namespace }}
+{{- end }}
+
+{{/*
+Create the checkpoint RBAC resource name.
+*/}}
+{{- define "logbook.checkpointRbacName" -}}
+{{- printf "%s-checkpoint" (include "logbook.fullname" . | trunc 52 | trimSuffix "-") | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create the leader election Lease name.
+*/}}
+{{- define "logbook.leaderElectionName" -}}
+{{- default "logbook-leader" .Values.logbook.leaderElection.name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create the leader election Lease namespace.
+*/}}
+{{- define "logbook.leaderElectionNamespace" -}}
+{{- default .Release.Namespace .Values.logbook.leaderElection.namespace }}
+{{- end }}
+
+{{/*
+Create the leader election RBAC resource name.
+*/}}
+{{- define "logbook.leaderElectionRbacName" -}}
+{{- printf "%s-leader-election" (include "logbook.fullname" . | trunc 47 | trimSuffix "-") | trunc 63 | trimSuffix "-" }}
+{{- end }}

--- a/helmchart/templates/checkpoint-role.yaml
+++ b/helmchart/templates/checkpoint-role.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.logbook.checkpoint.enabled (eq .Values.logbook.checkpoint.backend "configmap") -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    {{- include "logbook.labels" . | nindent 4 }}
+  name: {{ include "logbook.checkpointRbacName" . }}
+  namespace: {{ include "logbook.checkpointNamespace" . | quote }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  resourceNames:
+  - {{ include "logbook.checkpointName" . | quote }}
+  verbs:
+  - get
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+{{- end }}

--- a/helmchart/templates/checkpoint-rolebinding.yaml
+++ b/helmchart/templates/checkpoint-rolebinding.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.logbook.checkpoint.enabled (eq .Values.logbook.checkpoint.backend "configmap") -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "logbook.checkpointRbacName" . }}
+  namespace: {{ include "logbook.checkpointNamespace" . | quote }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "logbook.checkpointRbacName" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "logbook.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
+{{- end }}

--- a/helmchart/templates/deployment.yaml
+++ b/helmchart/templates/deployment.yaml
@@ -1,3 +1,6 @@
+{{- if and .Values.logbook.checkpoint.enabled (eq .Values.logbook.checkpoint.backend "file") (gt (int .Values.replicaCount) 1) -}}
+{{- fail "logbook.checkpoint.backend=file uses a per-pod emptyDir checkpoint and requires replicaCount=1; use backend=configmap for multiple replicas" -}}
+{{- end -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -50,10 +53,64 @@ spec:
             - name: LOGBOOK_LOG_FILENAME
               value: {{ .Values.logbook.log.filename | quote }}
             {{- end }}
+            - name: LOGBOOK_CHECKPOINT_ENABLED
+              value: {{ .Values.logbook.checkpoint.enabled | quote }}
+            {{- if .Values.logbook.checkpoint.backend }}
+            - name: LOGBOOK_CHECKPOINT_BACKEND
+              value: {{ .Values.logbook.checkpoint.backend | quote }}
+            {{- end }}
+            - name: LOGBOOK_CHECKPOINT_NAMESPACE
+              value: {{ include "logbook.checkpointNamespace" . | quote }}
+            - name: LOGBOOK_CHECKPOINT_NAME
+              value: {{ include "logbook.checkpointName" . | quote }}
+            {{- if .Values.logbook.checkpoint.path }}
+            - name: LOGBOOK_CHECKPOINT_PATH
+              value: {{ .Values.logbook.checkpoint.path | quote }}
+            {{- end }}
+            {{- if .Values.logbook.checkpoint.flushInterval }}
+            - name: LOGBOOK_CHECKPOINT_FLUSH_INTERVAL
+              value: {{ .Values.logbook.checkpoint.flushInterval | quote }}
+            {{- end }}
+            {{- if .Values.logbook.checkpoint.onExpiredResourceVersion }}
+            - name: LOGBOOK_CHECKPOINT_ON_EXPIRED_RESOURCE_VERSION
+              value: {{ .Values.logbook.checkpoint.onExpiredResourceVersion | quote }}
+            {{- end }}
+            - name: LOGBOOK_LEADER_ELECTION_ENABLED
+              value: {{ .Values.logbook.leaderElection.enabled | quote }}
+            - name: LOGBOOK_LEADER_ELECTION_NAMESPACE
+              value: {{ include "logbook.leaderElectionNamespace" . | quote }}
+            - name: LOGBOOK_LEADER_ELECTION_NAME
+              value: {{ include "logbook.leaderElectionName" . | quote }}
+            - name: LOGBOOK_LEADER_ELECTION_IDENTITY
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            {{- if .Values.logbook.leaderElection.leaseDuration }}
+            - name: LOGBOOK_LEADER_ELECTION_LEASE_DURATION
+              value: {{ .Values.logbook.leaderElection.leaseDuration | quote }}
+            {{- end }}
+            {{- if .Values.logbook.leaderElection.renewDeadline }}
+            - name: LOGBOOK_LEADER_ELECTION_RENEW_DEADLINE
+              value: {{ .Values.logbook.leaderElection.renewDeadline | quote }}
+            {{- end }}
+            {{- if .Values.logbook.leaderElection.retryPeriod }}
+            - name: LOGBOOK_LEADER_ELECTION_RETRY_PERIOD
+              value: {{ .Values.logbook.leaderElection.retryPeriod | quote }}
+            {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- if and .Values.logbook.checkpoint.enabled (eq .Values.logbook.checkpoint.backend "file") }}
+          volumeMounts:
+            - name: logbook-checkpoint
+              mountPath: /var/lib/logbook
+          {{- end }}
+      {{- if and .Values.logbook.checkpoint.enabled (eq .Values.logbook.checkpoint.backend "file") }}
+      volumes:
+        - name: logbook-checkpoint
+          emptyDir: {}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helmchart/templates/leader-election-role.yaml
+++ b/helmchart/templates/leader-election-role.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.logbook.leaderElection.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    {{- include "logbook.labels" . | nindent 4 }}
+  name: {{ include "logbook.leaderElectionRbacName" . }}
+  namespace: {{ include "logbook.leaderElectionNamespace" . | quote }}
+rules:
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  resourceNames:
+  - {{ include "logbook.leaderElectionName" . | quote }}
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+{{- end }}

--- a/helmchart/templates/leader-election-rolebinding.yaml
+++ b/helmchart/templates/leader-election-rolebinding.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.logbook.leaderElection.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "logbook.leaderElectionRbacName" . }}
+  namespace: {{ include "logbook.leaderElectionNamespace" . | quote }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "logbook.leaderElectionRbacName" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "logbook.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
+{{- end }}

--- a/helmchart/values.schema.json
+++ b/helmchart/values.schema.json
@@ -1,28 +1,59 @@
 {
   "$schema": "https://json-schema.org/draft-07/schema#",
   "type": "object",
+  "additionalProperties": false,
   "properties": {
+    "nameOverride": { "type": "string" },
+    "fullnameOverride": { "type": "string" },
     "replicaCount": {
       "type": "integer",
       "minimum": 1
     },
     "logbook": {
       "type": "object",
+      "additionalProperties": false,
       "properties": {
         "namespace": { "type": "string" },
         "log": {
           "type": "object",
+          "additionalProperties": false,
           "properties": {
             "format": { "type": "string", "enum": ["json", "text"] },
             "out": { "type": "string", "enum": ["stdout", "stderr", "file"] },
             "level": { "type": "string", "enum": ["debug", "info", "warn", "error"] },
             "filename": { "type": "string" }
           }
+        },
+        "checkpoint": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "backend": { "type": "string", "enum": ["configmap", "file"] },
+            "namespace": { "type": "string" },
+            "name": { "type": "string" },
+            "path": { "type": "string" },
+            "flushInterval": { "type": "string" },
+            "onExpiredResourceVersion": { "type": "string", "enum": ["skip-existing", "fail"] }
+          }
+        },
+        "leaderElection": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "namespace": { "type": "string" },
+            "name": { "type": "string" },
+            "leaseDuration": { "type": "string" },
+            "renewDeadline": { "type": "string" },
+            "retryPeriod": { "type": "string" }
+          }
         }
       }
     },
     "image": {
       "type": "object",
+      "additionalProperties": false,
       "properties": {
         "repository": { "type": "string" },
         "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] },
@@ -31,12 +62,54 @@
     },
     "serviceAccount": {
       "type": "object",
+      "additionalProperties": false,
       "properties": {
         "create": { "type": "boolean" },
         "annotations": { "type": "object" },
         "name": { "type": "string" },
         "automountServiceAccountToken": { "type": "boolean" }
       }
-    }
+    },
+    "podAnnotations": { "type": "object" },
+    "podLabels": { "type": "object" },
+    "podSecurityContext": {
+      "type": "object",
+      "properties": {
+        "runAsNonRoot": { "type": "boolean" },
+        "seccompProfile": {
+          "type": "object",
+          "properties": {
+            "type": { "type": "string" }
+          }
+        }
+      },
+      "additionalProperties": true
+    },
+    "securityContext": {
+      "type": "object",
+      "properties": {
+        "allowPrivilegeEscalation": { "type": "boolean" },
+        "capabilities": { "type": "object" },
+        "readOnlyRootFilesystem": { "type": "boolean" },
+        "runAsNonRoot": { "type": "boolean" },
+        "runAsUser": { "type": "integer" },
+        "runAsGroup": { "type": "integer" }
+      },
+      "additionalProperties": true
+    },
+    "resources": {
+      "type": "object",
+      "properties": {
+        "requests": { "type": "object" },
+        "limits": { "type": "object" }
+      },
+      "additionalProperties": true
+    },
+    "nodeSelector": { "type": "object" },
+    "tolerations": {
+      "type": "array",
+      "items": { "type": "object" }
+    },
+    "affinity": { "type": "object" }
   }
 }

--- a/helmchart/values.yaml
+++ b/helmchart/values.yaml
@@ -14,6 +14,34 @@ logbook:
     level: info
     # Full path of log file with filename. Only used when log.out is file.
     filename: k8s-events.log
+  checkpoint:
+    # Persist the last processed Kubernetes Event resourceVersion.
+    enabled: true
+    # Checkpoint backend. Valid values: configmap, file.
+    backend: configmap
+    # Namespace for the checkpoint ConfigMap. Defaults to the Helm release namespace.
+    namespace: ""
+    # Name of the checkpoint ConfigMap.
+    name: logbook-checkpoint
+    # File path when checkpoint.backend is file. The chart mounts a writable emptyDir at /var/lib/logbook for this backend.
+    path: /var/lib/logbook/checkpoint
+    # Coalesce checkpoint writes and flush the latest resourceVersion at this interval.
+    # Set to 0s to flush every observed event.
+    flushInterval: 5s
+    # Behavior when Kubernetes has compacted the saved resourceVersion.
+    # Valid values: skip-existing, fail.
+    onExpiredResourceVersion: skip-existing
+  leaderElection:
+    # Ensure only one Logbook replica streams events and writes checkpoints.
+    enabled: true
+    # Namespace for the leader election Lease. Defaults to the Helm release namespace.
+    namespace: ""
+    # Name of the leader election Lease.
+    name: logbook-leader
+    # Lease timing. Increase these values in clusters with high API latency.
+    leaseDuration: 15s
+    renewDeadline: 10s
+    retryPeriod: 2s
 
 image:
   repository: ghcr.io/sundi0331/logbook

--- a/logbook.yaml.sample
+++ b/logbook.yaml.sample
@@ -4,3 +4,14 @@ log:
   format: json
   out: stdout
   level: info
+checkpoint:
+  enabled: true
+  backend: configmap
+  flush_interval: 5s
+  on_expired_resource_version: skip-existing
+leader_election:
+  enabled: false
+  name: logbook-leader
+  lease_duration: 15s
+  renew_deadline: 10s
+  retry_period: 2s


### PR DESCRIPTION
## Summary

- Add Kubernetes Event resourceVersion checkpointing with ConfigMap and file backends.
- Add buffered checkpoint flushing and expired resourceVersion recovery behavior.
- Add Kubernetes Lease leader election for Helm deployments.
- Update Helm RBAC, values, schema, docs, sample config, and agent guidance.
- Add regression coverage for checkpointing, leader election, and long Helm-rendered RBAC names.

## Validation

- `GOCACHE=/tmp/logbook-go-cache GOMODCACHE=/tmp/logbook-go-mod-cache make verify`
- GitHub Actions on `dev` for `f12bfcbc0793a4e32053fc08873a87b7ce7a4359`: CI, CodeQL, and Container Image passed.